### PR TITLE
Update action.yml to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: ""
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: 'server'  

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -10,7 +10,7 @@ export const checkShallow = (): void => {
   }
 };
 export const gitStack = (AppName: string): void => {
-  execSync("heroku stack:set heroku-20");
+  execSync("heroku stack:set heroku-22");
   execSync("heroku plugins:install heroku-repo");
   execSync(`heroku repo:reset -a ${AppName}`);
 };


### PR DESCRIPTION
Fixes the following warning when runs, note I haven't actually tested this forked PR but this seems like the place to do it.

The following actions uses node12 which is deprecated and will be forced to run on node16: ElayGelbart/Heroku-Auto-Deployment@v1.0.6. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

<img width="1012" alt="Screenshot 2023-11-20 at 4 22 47 PM" src="https://github.com/ElayGelbart/Heroku-Auto-Deployment/assets/79464/29af734f-4ce1-4091-8939-1a4a2784046e">
